### PR TITLE
chore: normalize package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
-        "@railgun-reloaded/bytes": "github:railgun-reloaded/bytes#dev",
+        "@railgun-reloaded/bytes": "git+https://github.com/railgun-reloaded/bytes.git#dev",
         "circomlibjs": "^0.1.7",
         "poseidon-lite": "^0.3.0"
       },


### PR DESCRIPTION
Normalizes the `@railgun-reloaded/bytes` resolved URL from the shorthand `github:` form to the explicit `git+https://` form. Semantic no-op; keeps the lockfile stable across fresh `npm install` runs.