### PR TITLE
Replace node:crypto AES with @noble/ciphers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
         "@railgun-reloaded/bytes": "git+https://github.com/railgun-reloaded/bytes.git#dev",
         "circomlibjs": "^0.1.7",
@@ -955,6 +956,17 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
@@ -4756,9 +4768,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "dependencies": {
         "fdir": "^6.5.0",
@@ -5728,6 +5740,11 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="
     },
     "@noble/hashes": {
       "version": "1.8.0",
@@ -8351,9 +8368,9 @@
       "dev": true
     },
     "tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "requires": {
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@noble/ciphers": "^1.3.0",
     "@noble/hashes": "^1.8.0",
     "@railgun-reloaded/bytes": "git+https://github.com/railgun-reloaded/bytes.git#dev",
     "circomlibjs": "^0.1.7",

--- a/src/primitives/aes/aes.ts
+++ b/src/primitives/aes/aes.ts
@@ -1,5 +1,4 @@
-import { createCipheriv, createDecipheriv } from 'node:crypto'
-
+import { ctr, gcm } from '@noble/ciphers/aes'
 import { randomBytes } from '@noble/hashes/utils'
 
 import { CryptographyError } from '../errors'
@@ -64,11 +63,51 @@ const assertTagLength = (tag: Uint8Array): void => {
 }
 
 /**
+ * Concatenate a list of byte blocks into a single contiguous buffer.
+ * @param blocks - Blocks to join in order.
+ * @returns A new buffer holding every block back to back.
+ */
+const concatBlocks = (blocks: Uint8Array[]): Uint8Array => {
+  let length = 0
+  for (const block of blocks) {
+    length += block.byteLength
+  }
+
+  const joined = new Uint8Array(length)
+  let offset = 0
+  for (const block of blocks) {
+    joined.set(block, offset)
+    offset += block.byteLength
+  }
+
+  return joined
+}
+
+/**
+ * Split a buffer back into freshly-owned blocks matching the given lengths.
+ * @param buffer - Contiguous buffer to slice.
+ * @param lengths - Byte length of each output block, in order.
+ * @returns One block per length, each a standalone copy.
+ */
+const splitBlocks = (buffer: Uint8Array, lengths: number[]): Uint8Array[] => {
+  const blocks: Uint8Array[] = []
+  let offset = 0
+  for (const length of lengths) {
+    blocks.push(buffer.slice(offset, offset + length))
+    offset += length
+  }
+
+  return blocks
+}
+
+/**
  * AES-256 encryption helpers in GCM (authenticated) and CTR (streaming) modes.
  *
  * All inputs and outputs are `Uint8Array`. Keys must be 32 bytes; IVs are
  * generated internally on encrypt and read from the ciphertext bundle on
- * decrypt.
+ * decrypt. GCM and CTR are counter-mode stream ciphers, so the per-block
+ * data layout is preserved by encrypting the concatenated blocks in one shot
+ * and re-splitting the result at the original block boundaries.
  */
 class AES {
   /**
@@ -90,10 +129,11 @@ class AES {
     assertKeyLength(key)
 
     const iv = AES.getRandomIV()
-    const cipher = createCipheriv('aes-256-gcm', key, iv, { authTagLength: TAG_BYTES })
-    const data = plaintext.map((block) => new Uint8Array(cipher.update(block)))
-    cipher.final()
-    const tag = new Uint8Array(cipher.getAuthTag())
+    const sealed = gcm(key, iv).encrypt(concatBlocks(plaintext))
+
+    const tag = sealed.slice(sealed.byteLength - TAG_BYTES)
+    const body = sealed.subarray(0, sealed.byteLength - TAG_BYTES)
+    const data = splitBlocks(body, plaintext.map((block) => block.byteLength))
 
     return { iv, tag, data }
   }
@@ -114,13 +154,10 @@ class AES {
     assertTagLength(ciphertext.tag)
 
     try {
-      const decipher = createDecipheriv('aes-256-gcm', key, ciphertext.iv, { authTagLength: TAG_BYTES })
-      decipher.setAuthTag(ciphertext.tag)
+      const sealed = concatBlocks([...ciphertext.data, ciphertext.tag])
+      const plaintext = gcm(key, ciphertext.iv).decrypt(sealed)
 
-      const data = ciphertext.data.map((block) => new Uint8Array(decipher.update(block)))
-      decipher.final()
-
-      return data
+      return splitBlocks(plaintext, ciphertext.data.map((block) => block.byteLength))
     } catch (cause) {
       throw new CryptographyError('DecryptionFailed', 'Unable to decrypt ciphertext.', { cause })
     }
@@ -137,9 +174,8 @@ class AES {
     assertKeyLength(key)
 
     const iv = AES.getRandomIV()
-    const cipher = createCipheriv('aes-256-ctr', key, iv)
-    const data = plaintext.map((block) => new Uint8Array(cipher.update(block)))
-    cipher.final()
+    const body = ctr(key, iv).encrypt(concatBlocks(plaintext))
+    const data = splitBlocks(body, plaintext.map((block) => block.byteLength))
 
     return { iv, data }
   }
@@ -156,11 +192,9 @@ class AES {
     assertKeyLength(key)
     assertIvLength(ciphertext.iv)
 
-    const decipher = createDecipheriv('aes-256-ctr', key, ciphertext.iv)
-    const data = ciphertext.data.map((block) => new Uint8Array(decipher.update(block)))
-    decipher.final()
+    const plaintext = ctr(key, ciphertext.iv).decrypt(concatBlocks(ciphertext.data))
 
-    return data
+    return splitBlocks(plaintext, ciphertext.data.map((block) => block.byteLength))
   }
 }
 

--- a/test/aes.test.ts
+++ b/test/aes.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
-import { randomBytes } from 'node:crypto'
 import { test } from 'node:test'
 
+import { randomBytes } from '@noble/hashes/utils'
 import { hexToBytes } from '@railgun-reloaded/bytes'
 
 import type { CryptographyError } from '../src/index'

--- a/test/eddsa.test.ts
+++ b/test/eddsa.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
-import { randomBytes } from 'node:crypto'
 import { test } from 'node:test'
 
+import { randomBytes } from '@noble/hashes/utils'
 import { bigIntToBytes, bytesToBigInt, hexToBytes } from '@railgun-reloaded/bytes'
 
 import { BABYJUBJUB_SUBGROUP_ORDER, eddsa, initCircomlib, initializeEddsa } from '../src/index'


### PR DESCRIPTION
Swaps the AES-256-GCM/CTR helpers in `aes.ts` from `node:crypto` (`createCipheriv`/`createDecipheriv`) to the pure-JS `@noble/ciphers`. This removes the package's only hard dependency on a Node builtin, so it runs natively in browsers and React Native without a `node:crypto` polyfill.

Behaviour is unchanged — same public API, error codes, IV/tag handling, and byte-for-byte output. AES-GCM/CTR are deterministic, so the existing Wycheproof (GCM) and NIST SP 800-38A (CTR) known-answer vectors and the multi-block roundtrip tests already pin output compatibility. Test-only `randomBytes` usages move to `@noble/hashes/utils`.

`@noble/ciphers` is pinned to `^1.x` (dual CJS/ESM); v2 is ESM-only and would break this package's CommonJS consumers.